### PR TITLE
Add support for alternative domains

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -3,7 +3,7 @@
     "name": "wechat-need-web",
     "author": "lqzh",
     "homepage_url": "https://github.com/lqzhgood/wechat-need-web",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Allow the use of WeChat via webpage access",
     "permissions": [
         "declarativeNetRequest"
@@ -25,7 +25,10 @@
     },
     "host_permissions": [
         "https://wx.qq.com/*",
+        "https://web.weixin.qq.com/*",
         "https://web.wechat.com/*",
+        "https://web1.wechat.com/*",
+        "https://web2.wechat.com/*",
         "https://wx2.qq.com/*",
         "https://wx8.qq.com/*"
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,21 @@
 {
     "name": "wechat-need-web",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "wechat-need-web",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "license": "ISC",
             "dependencies": {
+                "@types/chrome": "^0.0.234",
+                "@types/node": "^18.16.3",
                 "sharp": "^0.32.1",
                 "ts-node": "^10.9.1",
                 "typescript": "^5.0.4"
             },
-            "devDependencies": {
-                "@types/chrome": "^0.0.234",
-                "@types/node": "^18.16.3"
-            }
+            "devDependencies": {}
         },
         "node_modules/@cspotcode/source-map-support": {
             "version": "0.8.1",
@@ -75,7 +74,6 @@
             "version": "0.0.234",
             "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.234.tgz",
             "integrity": "sha512-4JofeJBUPFf8Qy9ZiOif5jp5V4tG/WaFVPyb11E6Zmvx1q5j+X7LR/zWmj3lhbliaFxTMY/51GjMdpZOiUWjqQ==",
-            "dev": true,
             "dependencies": {
                 "@types/filesystem": "*",
                 "@types/har-format": "*"
@@ -85,7 +83,6 @@
             "version": "0.0.32",
             "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
             "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
-            "dev": true,
             "dependencies": {
                 "@types/filewriter": "*"
             }
@@ -93,14 +90,12 @@
         "node_modules/@types/filewriter": {
             "version": "0.0.29",
             "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
-            "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==",
-            "dev": true
+            "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ=="
         },
         "node_modules/@types/har-format": {
             "version": "1.2.10",
             "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.10.tgz",
-            "integrity": "sha512-o0J30wqycjF5miWDKYKKzzOU1ZTLuA42HZ4HE7/zqTOc/jTLdQ5NhYWvsRQo45Nfi1KHoRdNhteSI4BAxTF1Pg==",
-            "dev": true
+            "integrity": "sha512-o0J30wqycjF5miWDKYKKzzOU1ZTLuA42HZ4HE7/zqTOc/jTLdQ5NhYWvsRQo45Nfi1KHoRdNhteSI4BAxTF1Pg=="
         },
         "node_modules/@types/node": {
             "version": "18.16.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wechat-need-web",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Allow WeChat to access the webpage.",
     "main": "index.js",
     "scripts": {

--- a/src/const.ts
+++ b/src/const.ts
@@ -26,7 +26,10 @@ export const WECHAT_HEADERS: Readonly<{
 
 export const WECHAT_URLS: Readonly<string[]> = [
     "https://wx.qq.com/*",
+    "https://web.weixin.qq.com/*",
     "https://web.wechat.com/*",
+    "https://web1.wechat.com/*",
+    "https://web2.wechat.com/*",
     "https://wx2.qq.com/*",
     "https://wx8.qq.com/*",
 ];


### PR DESCRIPTION
WeChat Web can be accessed through the following domains:

- [web.weixin.qq.com](https://web.weixin.qq.com/)
- [web1.wechat.com](https://web1.wechat.com/)
- [web2.wechat.com](https://web1.wechat.com/)

This PR serves to add support for these alternative domains.