### PR TITLE
Minor improvements here and there

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,15 @@
+import { isSupportedPlatform } from 'utils';
 import { PLATFORM } from './const';
 import { Make } from './lib';
 
 (async () => {
     const [platform] = process.argv.slice(2);
 
-    if (!Object.values(PLATFORM).includes(platform as PLATFORM)) {
+    if (!isSupportedPlatform(platform)) {
         console.error(`${platform} not support, need ${Object.keys(PLATFORM)}`);
         throw new Error('not support');
     }
-    const m = new Make(platform as PLATFORM);
+    const m = new Make(platform);
     await m.makeManifest();
     m.copyStatic();
     m.makeRules();

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import sharp from 'sharp';
 
-import { deleteFolderRecursive, w } from './utils';
+import { w } from './utils';
 
 import { PLATFORM, FILE_RULE, OUT_DIR, ResourceType, WECHAT_HEADERS, WECHAT_URLS } from './const';
 import { readSrcJson } from './utils';
@@ -20,7 +20,7 @@ export class Make {
         this.outDir = OUT_DIR(this.platform);
 
         if (fs.existsSync(this.outDir)) {
-            deleteFolderRecursive(this.outDir);
+            fs.rmSync(this.outDir, { recursive: true, force: true });
         }
         fs.mkdirSync(this.outDir);
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,15 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { OUT_DIR } from './const';
+import { PLATFORM } from './const';
 export function w(f: string, data: object) {
     fs.writeFileSync(f, JSON.stringify(data, null, 4), 'utf-8');
 }
 
 export function readSrcJson(f: string) {
     return JSON.parse(fs.readFileSync(path.join(__dirname, f), 'utf-8'));
+}
+
+export function isSupportedPlatform(platform: string): platform is PLATFORM {
+    return Object.values(PLATFORM).includes(platform as any);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,20 +9,3 @@ export function w(f: string, data: object) {
 export function readSrcJson(f: string) {
     return JSON.parse(fs.readFileSync(path.join(__dirname, f), 'utf-8'));
 }
-
-export function deleteFolderRecursive(p: string) {
-    if (fs.existsSync(p)) {
-        fs.readdirSync(p).forEach(function (file) {
-            const curPath = p + '/' + file;
-            if (fs.lstatSync(curPath).isDirectory()) {
-                // 递归删除子目录
-                deleteFolderRecursive(curPath);
-            } else {
-                // 删除文件
-                fs.unlinkSync(curPath);
-            }
-        });
-        // 删除空目录
-        fs.rmdirSync(p);
-    }
-}


### PR DESCRIPTION
The PR does 2 things:

- Remove the `deleteFolderRecursive` implementation, prefer the built-in `fs.rmSync` method instead
- Remove `platform as PLATFORM`, prefer type narrowing